### PR TITLE
Remove redundant directive name check causing case-sensitivity issue

### DIFF
--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -15,12 +15,12 @@ The extension provides the following configuration:
                   - mock ``toctree`` directive in default mode
                   - mock ``contents`` directive in ``hide`` mode
 
-:mock_default_mode: (Type: ``str``, ''Default: ``'hide'``)
+:mock_default_mode: (Type: ``str``, Default: ``'hide'``)
 
                     The default mode for mocking a directive/role.
                     Available values:
 
                     :hide: Hide the directive, it will not be seen on the document.
-                    :literal_block: Show the raw text of directive in a `literal block`__
+                    :literal: Show the raw text of directive in a `literal block`__
 
 __ https://docutils.sourceforge.io/docs/user/rst/quickref.html#literal-blocks

--- a/src/sphinxnotes/mock/__init__.py
+++ b/src/sphinxnotes/mock/__init__.py
@@ -3,7 +3,7 @@ from typing import List, Dict
 
 from sphinx.util import logging
 from sphinx.application import Sphinx
-from sphinx.config import Config
+from sphinx.config import Config, ENUM
 from sphinx.util.docutils import SphinxDirective
 
 from docutils.parsers.rst import directives
@@ -24,43 +24,69 @@ class MockOptionSpec(Dict):
         return directives.unchanged
 
 
-class MockDirective(SphinxDirective):
+class _MockDirectiveLiteral(SphinxDirective):
+    """Mock directive that shows the directive as a literal block."""
     optional_arguments = 1
     final_argument_whitespace = True
     option_spec = MockOptionSpec()
     has_content = True
 
     def run(self) -> List[nodes.Node]:
-        mode = None
-        for d in self.config.mock_directives:
-            name = d if isinstance(d, str) else d[0]
-            if self.name != name:
-                continue
-            mode = self.config.mock_default_mode if isinstance(d, str) else d[1]
-            break
+        literal = nodes.literal_block(self.block_text, self.block_text)
+        literal['language'] = 'rst'
+        return [literal]
 
-        if mode == 'literal':
-            literal = nodes.literal_block(self.block_text, self.block_text)
-            literal['language'] = 'rst'
-            return [literal]
-        elif mode == 'hide':
-            return []
-        else:
-            raise ValueError('unsupported mock mode')
 
+class _MockDirectiveHide(SphinxDirective):
+    """Mock directive that hides the directive content."""
+    optional_arguments = 1
+    final_argument_whitespace = True
+    option_spec = MockOptionSpec()
+    has_content = True
+
+    def run(self) -> List[nodes.Node]:
+        return []
+
+
+_MOCK_DIRECTIVE_CLASSES = {
+    'literal': _MockDirectiveLiteral,
+    'hide': _MockDirectiveHide,
+}
 
 
 def _config_inited(app:Sphinx, config:Config) -> None:
     for d in config.mock_directives:
         name = d if isinstance(d, str) else d[0]
-        app.add_directive(name, MockDirective, override=True)
+        mode = config.mock_default_mode if isinstance(d, str) else d[1]
+
+        if mode not in ('literal', 'hide'):
+            raise ValueError(
+                f'Invalid mock mode for directive "{name}": {mode}. '
+                f'Must be "literal" or "hide"'
+            )
+
+        directive_class = _MOCK_DIRECTIVE_CLASSES[mode]
+        app.add_directive(name, directive_class, override=True)
 
 
 def setup(app:Sphinx) -> Dict:
     """Sphinx extension entrypoint."""
 
-    app.add_config_value('mock_directives', [], 'env')
-    app.add_config_value('mock_default_mode', 'hide', 'env')
+    app.add_config_value(
+        'mock_directives',
+        default=[],
+        rebuild='env',
+        types=list,
+        description='List of directive names to mock. Each item can be a string (directive name) '
+                    'or a tuple (directive name, mode).'
+    )
+    app.add_config_value(
+        'mock_default_mode',
+        default='hide',
+        rebuild='env',
+        types=ENUM('hide', 'literal'),
+        description='Default mode for mocking directives. Valid values: "hide", "literal".'
+    )
     app.connect('config-inited', _config_inited)
 
     return {'version': __version__}


### PR DESCRIPTION
Found directive name matching issue in this package when trying to build `silverrainz.github.io` to validate some subtle changes QaQ

# Problem

```sh
# fetch repo
git clone --depth 1 https://github.com/SilverRainZ/silverrainz.github.io.git
cd silverrainz.github.io

# dependencies
uv venv
uv pip install -r requirements.txt

# try build <- fail here
uv run make
```

**Error log:**

```
      File "/REDACTED/silverrainz.github.io/.venv/lib/python3.12/site-packages/sphinxnotes/mock/__init__.py", line 49, in run
        raise ValueError('unsupported mock mode')
    ValueError: unsupported mock mode
```


<details>

<summary>full log:</summary>

```
Running Sphinx v8.2.3
Deployment: Deployment.Local
loading translations [zh_CN]... done
WARNING: while setting up extension sphinxnotes.snippet: extension 'sphinxnotes.snippet' has no setup() function; is it really a Sphinx extension module?
loading pickled environment... The configuration has changed (10 options: 'any_schemas', 'html_context', 'html_css_files', 'html_domain_indices', 'html_js_files', ...)
done
building [html]: template versionchanges.html has been changed since the previous build, all docs will be rebuilt
building [html]: targets for 270 source files that are out of date
updating environment: 0 added, 85 changed, 0 removed
WARNING: the sphinxnotes.extweb extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit
WARNING: doing serial read
dump any domain data to any-objects.json... [100%] term-db1d470


Versions
========

* Platform:         linux; (Linux-6.14.1-arch1-1-x86_64-with-glibc2.41)
* Python version:   3.12.11 (CPython)
* Sphinx version:   8.2.3
* Docutils version: 0.21.2
* Jinja2 version:   3.1.6
* Pygments version: 2.19.2

Last Messages
=============



    dump any domain data to any-objects.json... [100%]
    term-dfcbb9b


    dump any domain data to any-objects.json... [100%]
    term-db1d470

Loaded Extensions
=================

* sphinx.ext.mathjax (8.2.3)
* alabaster (1.0.0)
* sphinxcontrib.applehelp (2.0.0)
* sphinxcontrib.devhelp (2.0.0)
* sphinxcontrib.htmlhelp (2.1.0)
* sphinxcontrib.serializinghtml (2.0.0)
* sphinxcontrib.qthelp (2.0.0)
* sphinxcontrib.email (0.3.6)
* sphinx.ext.githubpages (8.2.3)
* sphinxnotes.strike (1.3)
* sphinxcontrib.plantuml (unknown version)
* sphinxcontrib.asciinema (0.4.2)
* sphinx_copybutton (0.5.2)
* sphinxcontrib.youtube (1.4.1)
* sphinxnotes.extweb (unknown version)
* sphinx_design (0.6.1)
* sphinx_simplepdf (unknown version)
* sphinxnotes.mock (1.0.2)
* sphinx.ext.todo (8.2.3)
* sphinx.ext.extlinks (8.2.3)
* sphinxnotes.any (3.0a7.post1.dev1+g8ca6aef1e)
* ablog (0.11.12)
* sphinxnotes.snippet (unknown version)
* sphinxnotes.lilypond (2.4)
* sphinxnotes.recentupdate (1.0b2)
* sphinxnotes.comboroles (0.1.0)
* sphinxcontrib.globalsubs (0.1.0)
* sphinxnotes.fasthtml (unknown version)
* sphinx.ext.graphviz (8.2.3)
* sphinxnotes.poc (0.0.post1.dev4+g0690743f5)
* sphinx_book_theme (unknown version)
* pydata_sphinx_theme (unknown version)

Traceback
=========

      File "/REDACTED/silverrainz.github.io/.venv/lib/python3.12/site-packages/sphinxnotes/mock/__init__.py", line 49, in run
        raise ValueError('unsupported mock mode')
    ValueError: unsupported mock mode
```

</details>

# Analysis and Solution

I found the directive name in runtime could be `'Contents'`, but the config from the blog is `'contents'`, resulting mode being resolved as `None` and raising the error. (I did not investigate why the directive name is `'Contents'` instead of `'contents'`, it looks like Sphinx is normalizing directive name to capital case?)

At the first look we could update the mock_directives to be `'Contents'` (with uppercase `C`) in https://github.com/SilverRainZ/silverrainz.github.io/blob/cf5fcad88b7727871af06c06f0d39ffda51a5606/conf.py#L207.

However according to [reST spec](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#directives:~:text=Directive%20types%20are%20case%2Dinsensitive%20single%20words%20(alphanumerics%20plus%20isolated%20internal%20hyphens%2C%20underscores%2C%20plus%20signs%2C%20colons%2C%20and%20periods%3B%20no%20whitespace).):

>  Directive types are case-insensitive single words (alphanumerics plus isolated internal hyphens, underscores, plus signs, colons, and periods; no whitespace).

We could make the logic in sphinxnotes/mock case-insensitive to avoid such issues in the future.

Another fix is making the directive name matching in `MockDirective` case-insensive: https://github.com/sphinx-notes/mock/blob/5692302bf68f5e5a0bb59a13b4e5752036369405/src/sphinxnotes/mock/__init__.py#L37

I found it is redundant to check directive name in `MockDirective` since [`app.add_directive(name, cls, ...)`](https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_directive) already binds a directive name to the given directive class.

Finally, I elimated the redundant directive name checks in `MockDirective` class and updated the arguments for `app.add_directive()` to make Sphinx handle the directive name matching for us.

# Additional Changes

- Updated outdated docs